### PR TITLE
SimpleDiskCache fix

### DIFF
--- a/src/base_meli.php
+++ b/src/base_meli.php
@@ -24,7 +24,8 @@ class SimpleDiskCache {
     }
 
     private function encodeFileName($data) {
-        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        return rtrim(md5(json_encode($data)));
+        /* return rtrim(strtr(base64_encode($data), '+/', '-_'), '='); */
     }
 
     private function getPath($key) {


### PR DESCRIPTION
Fix to "name too long" error when SimpleDiskCache tried to create/write file.
