### PR TITLE
URL Logout

### DIFF
--- a/MercadoLivre/meli.php
+++ b/MercadoLivre/meli.php
@@ -14,6 +14,7 @@ class Meli {
     protected static $API_ROOT_URL = "https://api.mercadolibre.com";
     protected static $AUTH_URL     = "http://auth.mercadolivre.com.br/authorization";
     protected static $OAUTH_URL    = "/oauth/token";
+    protected static $LOGOUT_URL     = "https://auth.mercadolibre.com.br/lgz/logout/cleanUp";
 
     /**
      * Configuration for CURL
@@ -47,6 +48,25 @@ class Meli {
         $this->refresh_token = $refresh_token;
     }
 
+    /**
+     * Return an string with a complete Meli logout url.
+     * NOTE: You can modify the $LOGOUT_URL to change the language of login
+     * 
+     * @todo (2014-10-20) Redirection from MercadoLire not working momentarily, so that the user will be anchored in MercadoLire.
+     * @param string $redirect_uri
+     * @return string
+     */
+    public function getLogoutUrl($redirect_uri) {
+        $this->redirect_uri = $redirect_uri;
+        $params = array(
+          "platform_id" => 'ml',
+          "main_platform" => 'ml',
+          "go" => $redirect_uri //todo: temporarily not work, we must solve
+            );
+        $logout_uri = self::$LOGOUT_URL."?".http_build_query($params);
+        return $logout_uri;
+    }
+    
     /**
      * Return an string with a complete Meli login url.
      * NOTE: You can modify the $AUTH_URL to change the language of login

--- a/examples/example_logout.php
+++ b/examples/example_logout.php
@@ -1,0 +1,47 @@
+<?php
+session_start('teste');
+
+require '../MercadoLivre/meli.php';
+
+$meli = new Meli('APP_ID', 'SECRET_KEY', $_SESSION['access_token'], $_SESSION['refresh_token']);
+
+if($_GET['code'] || $_SESSION['access_token']) {
+
+	// If code exist and session is empty
+	if($_GET['code'] && !($_SESSION['access_token'])) {
+		// If the code was in get parameter we authorize
+		$user = $meli->authorize($_GET['code'], 'http://localhost/PHPSDK/examples/example_login.php');
+		
+		// Now we create the sessions with the authenticated user
+		$_SESSION['access_token'] = $user['body']->access_token;
+		$_SESSION['expires_in'] = time() + $user['body']->expires_in;
+		$_SESSION['refresh_token'] = $user['body']->refresh_token;
+	} else {
+		// We can check if the access token in invalid checking the time
+		if($_SESSION['expires_in'] < time()) {
+			try {
+				// Make the refresh proccess
+				$refresh = $meli->refreshAccessToken();
+
+				// Now we create the sessions with the new parameters
+				$_SESSION['access_token'] = $refresh['body']->access_token;
+				$_SESSION['expires_in'] = time() + $refresh['body']->expires_in;
+				$_SESSION['refresh_token'] = $refresh['body']->refresh_token;
+			} catch (Exception $e) {
+			  	echo "Exception: ",  $e->getMessage(), "\n";
+			}
+		}
+	}
+
+	echo '<pre>';
+		print_r($_SESSION);
+	echo '</pre>';
+       
+       $logout_url =  $meli->getLogoutUrl("http://localhost/PHPSDK/examples/example_login.php");
+       echo '<a href="'.$logout_url.'">Logout</a>';
+        
+        
+	
+} else {
+	echo '<a href="' . $meli->getAuthUrl('http://localhost/PHPSDK/examples/example_login.php') . '">Login using MercadoLibre oAuth 2.0</a>';
+}


### PR DESCRIPTION
Debido a que no es posible cerrar sesión desde el sdk, pues el sdk-PHP NO borra cookies, he creado el método getLogoutUrl que retorna la url para cerrar sesión, debemos pasarle como parámetro una url de redirección a la cual será redireccionado el usuario luego de cerrar sesión. Dicha url viajará en el parámetro "go", la cual MercadoLibre debería tomar y hacer la redirección.

El problema principal es que MercadoLibre no está realizando dicha redirección, se debería solucionar ese bug (si es que es un bug) o agregar una redirect_url o algo por el estilo, para que todo esto funcione. Hoy funciona el cierre de sesión correctamente, solo que no redirecciona, se queda en MercadoLibre.

Me han proporcionado la siguiente url para cerrar sesion:
https://auth.mercadolibre.com.ar/lgz/logout/cleanUp

Sigo haciendo pruebas, al parecer no se cierra la sesion con la url que he puesto en el meli.php:
protected static $LOGOUT_URL     = "https://auth.mercadolibre.com.ar/lgz/logout/cleanUp";
Pero si con la siguiente:
protected static $LOGOUT_URL     = "https://www.mercadolibre.com/jms/mla/lgz/logout";