### PR TITLE
Validation for optional value.

### DIFF
--- a/Meli/meli.php
+++ b/Meli/meli.php
@@ -106,7 +106,7 @@ class Meli {
         if($request["httpCode"] == 200) {             
             $this->access_token = $request["body"]->access_token;
 
-            if($request["body"]->refresh_token)
+            if(isset($request["body"]->refresh_token) && !empty($request["body"]->refresh_token))
                 $this->refresh_token = $request["body"]->refresh_token;
 
             return $request;


### PR DESCRIPTION
As described in documentation https://developers.mercadolibre.com.ar/es_ar/autenticacion-y-autorizacion#Refresh-token , application must have selected option "offline_access" to return a value, so this commit check if variable exist and is not empty. Meli library fail if application in Mercado Libre backend does not have set "offline_access" option.